### PR TITLE
Update try-catch-callback to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "gana-compile": "^1.0.1",
-    "try-catch-callback": "^1.0.2"
+    "try-catch-callback": "^2.0.1"
   },
   "devDependencies": {
     "browserify": "^13.1.0",


### PR DESCRIPTION
The [try-catch-callback](https://github.com/hybridables/try-catch-callback) dependency has a new major version, and the usage in this project is compatible.

 - [Changelog](https://github.com/hybridables/try-catch-callback/blob/master/CHANGELOG.md)